### PR TITLE
screen breakpoint service

### DIFF
--- a/src/app/core/services/df-breakpoint.service.spec.ts
+++ b/src/app/core/services/df-breakpoint.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { DfBreakpointService } from './df-breakpoint.service';
+import { of } from 'rxjs';
+
+describe('DfBreakpointService', () => {
+  let service: DfBreakpointService;
+  let breakpointObserverMock: jest.Mocked<BreakpointObserver>;
+
+  beforeEach(() => {
+    breakpointObserverMock = {
+      observe: jest.fn().mockReturnValue(
+        of({
+          matches: false,
+          breakpoints: {
+            [Breakpoints.XSmall]: false,
+            [Breakpoints.Small]: false,
+          },
+        })
+      ),
+    } as any;
+
+    TestBed.configureTestingModule({
+      providers: [
+        DfBreakpointService,
+        { provide: BreakpointObserver, useValue: breakpointObserverMock },
+      ],
+    });
+  });
+
+  it('should return false for non-small screens', () => {
+    service = TestBed.inject(DfBreakpointService);
+    service.isSmalllScreen$.subscribe((isSmallScreen: boolean) => {
+      expect(isSmallScreen).toBeFalsy();
+    });
+  });
+  it('should return true for XSmall screens', () => {
+    breakpointObserverMock.observe.mockReturnValue(
+      of({
+        matches: true,
+        breakpoints: {
+          [Breakpoints.XSmall]: true,
+          [Breakpoints.Small]: false,
+        },
+      })
+    );
+    service = TestBed.inject(DfBreakpointService);
+    service.isSmalllScreen$.subscribe((isSmallScreen: boolean) => {
+      expect(isSmallScreen).toBeTruthy();
+    });
+  });
+
+  it('should return true for Small screens', () => {
+    breakpointObserverMock.observe.mockReturnValue(
+      of({
+        matches: true,
+        breakpoints: {
+          [Breakpoints.XSmall]: false,
+          [Breakpoints.Small]: true,
+        },
+      })
+    );
+    service = TestBed.inject(DfBreakpointService);
+    service.isSmalllScreen$.subscribe((isSmallScreen: boolean) => {
+      expect(isSmallScreen).toBeTruthy();
+    });
+  });
+});

--- a/src/app/core/services/df-breakpoint.service.ts
+++ b/src/app/core/services/df-breakpoint.service.ts
@@ -1,0 +1,16 @@
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Injectable } from '@angular/core';
+import { map } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DfBreakpointService {
+  constructor(private breakpointObserver: BreakpointObserver) {}
+
+  isSmalllScreen$ = this.breakpointObserver
+    .observe([Breakpoints.XSmall, Breakpoints.Small])
+    .pipe(map(result => result.matches));
+
+  //add new observable for other breakpoints as needed
+}


### PR DESCRIPTION
root injected service that can be utilized to observe breakpoints. Currently setup to use default breakpoints provided by angular material 
https://material.angular.io/cdk/layout/overview