### PR TITLE
Add api-docs iframe

### DIFF
--- a/src/app/adf-api-docs/df-api-docs-routing.module.ts
+++ b/src/app/adf-api-docs/df-api-docs-routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { DfApiDocsComponent } from './df-api-docs/df-api-docs.component';
+
+const routes = [
+  {
+    path: '',
+    component: DfApiDocsComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class DfApiDocsRoutingModule {}

--- a/src/app/adf-api-docs/df-api-docs.module.ts
+++ b/src/app/adf-api-docs/df-api-docs.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DfApiDocsComponent } from './df-api-docs/df-api-docs.component';
+import { DfApiDocsRoutingModule } from './df-api-docs-routing.module';
+import { SafePipe } from '../shared/utilities/safe-url-pipe';
+
+@NgModule({
+  declarations: [DfApiDocsComponent, SafePipe],
+  imports: [CommonModule, DfApiDocsRoutingModule],
+})
+export class DfApiDocsModule {}

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
@@ -1,0 +1,1 @@
+<iframe [src]="serverUrl | safe"></iframe>

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
@@ -1,0 +1,4 @@
+iframe {
+  width: 100%;
+  height: 100%;
+}

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { INSTANCE_BASE_URL } from 'src/app/core/constants/urls';
+
+@Component({
+  selector: 'df-api-docs',
+  templateUrl: './df-api-docs.component.html',
+  styleUrls: ['./df-api-docs.component.scss'],
+})
+export class DfApiDocsComponent {
+  serverUrl = `${INSTANCE_BASE_URL}/df-api-docs-ui/dist/index.html?admin_app=1`;
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -65,6 +65,12 @@ const routes: Routes = [
       import('./adf-reports/adf-reports.module').then(m => m.AdfReportsModule),
     canActivate: [loggedInGuard],
   },
+  {
+    path: ROUTES.APIDOCS,
+    loadChildren: () =>
+      import('./adf-api-docs/df-api-docs.module').then(m => m.DfApiDocsModule),
+    canActivate: [loggedInGuard],
+  },
 ];
 
 @NgModule({

--- a/src/app/core/constants/urls.ts
+++ b/src/app/core/constants/urls.ts
@@ -1,5 +1,8 @@
 export const BASE_URL = '/api/v2';
 
+// change this url to the address of the instance
+export const INSTANCE_BASE_URL = 'http://localhost';
+
 export enum URLS {
   SYSTEM = `${BASE_URL}/system`,
   ENVIRONMENT = `${BASE_URL}/system/environment`,

--- a/src/app/shared/utilities/safe-url-pipe.ts
+++ b/src/app/shared/utilities/safe-url-pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'safe',
+})
+export class SafePipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+  transform(url: string) {
+    return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+  }
+}


### PR DESCRIPTION
- adds a component that contains an iframe that renders the service api docs from a url

Currently when rendered, the iframe encounters an error which is shown in the following screenshot: 

![x-frame-options-error](https://github.com/dreamfactorysoftware/df-admin-interface/assets/122292164/9da16844-aac6-4dcb-b303-3579467cb4de)
