### PR TITLE
Fix root cause of failing scheduler tests

### DIFF
--- a/src/app/adf-scheduler/df-scheduler/df-scheduler.component.ts
+++ b/src/app/adf-scheduler/df-scheduler/df-scheduler.component.ts
@@ -108,33 +108,31 @@ export class DfSchedulerComponent implements OnInit, OnDestroy {
         this.userServicesDropdownOptions = data.data.resource;
       });
 
-    const id = this.activatedRoute.snapshot.paramMap.get('id');
+    this.activatedRoute.data
+      .pipe(takeUntil(this.destroyed$))
+      .subscribe((data: any) => {
+        this.scheduleToEdit = data.schedulerObject;
 
-    if (id) {
-      this.activatedRoute.data
-        .pipe(takeUntil(this.destroyed$))
-        .subscribe((data: any) => {
-          this.scheduleToEdit = data.schedulerObject;
+        if (this.scheduleToEdit) {
+          this.log = this.scheduleToEdit.taskLogByTaskId?.content ?? '';
 
-          this.log = this.scheduleToEdit?.taskLogByTaskId?.content ?? '';
-
-          this.getServiceAccessList(this.scheduleToEdit?.serviceId as number);
+          this.getServiceAccessList(this.scheduleToEdit.serviceId as number);
 
           this.formGroup.setValue({
-            name: this.scheduleToEdit?.name,
-            description: this.scheduleToEdit?.description,
-            active: this.scheduleToEdit?.isActive,
-            serviceId: this.scheduleToEdit?.serviceId,
-            component: this.scheduleToEdit?.component,
-            method: this.scheduleToEdit?.verb,
-            frequency: this.scheduleToEdit?.frequency,
+            name: this.scheduleToEdit.name,
+            description: this.scheduleToEdit.description,
+            active: this.scheduleToEdit.isActive,
+            serviceId: this.scheduleToEdit.serviceId,
+            component: this.scheduleToEdit.component,
+            method: this.scheduleToEdit.verb,
+            frequency: this.scheduleToEdit.frequency,
           });
 
-          if (this.scheduleToEdit?.verb !== 'GET') {
-            this.addPayloadField(this.scheduleToEdit?.payload as string);
+          if (this.scheduleToEdit.verb !== 'GET') {
+            this.addPayloadField(this.scheduleToEdit.payload as string);
           }
-        });
-    }
+        }
+      });
 
     this.formGroup
       .get('method')
@@ -282,19 +280,17 @@ export class DfSchedulerComponent implements OnInit, OnDestroy {
       };
 
       if (this.scheduleToEdit) {
-        // edit mode
         return {
-          lastModifiedDate: this.scheduleToEdit?.lastModifiedDate as string,
-          lastModifiedById: this.scheduleToEdit?.lastModifiedById as number,
+          lastModifiedDate: this.scheduleToEdit.lastModifiedDate as string,
+          lastModifiedById: this.scheduleToEdit.lastModifiedById as number,
           hasLog: !!this.scheduleToEdit.taskLogByTaskId,
-          createdDate: this.scheduleToEdit?.createdDate as string,
-          createdById: this.scheduleToEdit?.createdById as number,
+          createdDate: this.scheduleToEdit.createdDate as string,
+          createdById: this.scheduleToEdit.createdById as number,
           id: this.scheduleToEdit.id,
           ...payload,
         } as UpdateSchedulePayload;
       }
 
-      // create mode
       return { ...payload, id: null } as CreateSchedulePayload;
     }
 

--- a/src/app/shared/components/df-ace-editor/df-ace-editor.component.ts
+++ b/src/app/shared/components/df-ace-editor/df-ace-editor.component.ts
@@ -75,6 +75,6 @@ export class DfAceEditorComponent
   }
 
   ngOnDestroy(): void {
-    this.editor.destroy();
+    if (this.editor) this.editor.destroy();
   }
 }


### PR DESCRIPTION
- Updates how the scheduler object selected for edit is fetched as it was causing the scheduler tests to fail
- Adds an if check in the `onDestroy` check for the ace editor component as that was also causing the scheduler tests to fail