### PR TITLE
chore: new schema table fixes

### DIFF
--- a/src/app/adf-roles/df-roles-access/df-roles-access.component.html
+++ b/src/app/adf-roles/df-roles-access/df-roles-access.component.html
@@ -86,7 +86,7 @@
                     multiple
                     panelWidth="null"
                     (selectionChange)="accessChange(i, $event.value)">
-                    <mat-option [value]="0" checked>All</mat-option>
+                    <!-- <mat-option [value]="0" checked>All</mat-option> -->
                     <mat-option
                       *ngFor="let option of accessOptions"
                       [value]="option.value">

--- a/src/app/adf-roles/df-roles-access/df-roles-access.component.ts
+++ b/src/app/adf-roles/df-roles-access/df-roles-access.component.ts
@@ -143,6 +143,7 @@ export class DfRolesAccessComponent implements OnInit {
     // "GET requests without a resource are not currently supported by the 'email' service."
     if (service === 'email') {
       this.componentOptions.push({ serviceId, components: ['*'] });
+      return;
     }
 
     if (

--- a/src/app/adf-schema/df-table-details/df-table-details.component.ts
+++ b/src/app/adf-schema/df-table-details/df-table-details.component.ts
@@ -98,12 +98,45 @@ export class DfTableDetailsComponent implements OnInit {
   save() {
     if (this.tableDetailsForm.invalid) return;
 
-    const data = this.tableDetailsForm.value;
-    const payload = {
-      resource: [data],
-    };
-
     if (this.type === 'create') {
+      const data = this.tableDetailsForm.value;
+      data.field = [
+        {
+          alias: null,
+          name: 'id',
+          label: 'Id',
+          description: null,
+          native: [],
+          type: 'id',
+          dbType: null,
+          length: null,
+          precision: null,
+          scale: null,
+          default: null,
+          required: false,
+          allowNull: false,
+          fixedLength: false,
+          supportsMultibyte: false,
+          autoIncrement: true,
+          isPrimaryKey: false,
+          isUnique: false,
+          isIndex: false,
+          isForeignKey: false,
+          refTable: null,
+          refField: null,
+          refOnUpdate: null,
+          refOnDelete: null,
+          picklist: null,
+          validation: null,
+          dbFunction: null,
+          isVirtual: false,
+          isAggregate: false,
+        },
+      ];
+      const payload = {
+        resource: [data],
+      };
+
       this.crudService
         .create(
           payload,
@@ -114,14 +147,20 @@ export class DfTableDetailsComponent implements OnInit {
           `${this.dbName}/_schema`
         )
         .subscribe(() => {
-          this.goBack();
+          this.router.navigate(['../', this.tableDetailsForm.value.name], {
+            relativeTo: this.activatedRoute,
+          });
         });
     } else if (this.type === 'edit') {
       const tableName = this.tableDetailsForm.get('name')?.value;
       this.crudService
-        .patch(`${this.dbName}/_schema/${tableName}`, data, {
-          snackbarSuccess: 'schema.alerts.updateSuccess',
-        })
+        .patch(
+          `${this.dbName}/_schema/${tableName}`,
+          { resource: [this.tableDetailsForm.getRawValue()] },
+          {
+            snackbarSuccess: 'schema.alerts.updateSuccess',
+          }
+        )
         .subscribe(() => {
           this.goBack();
         });


### PR DESCRIPTION
- updates schema table create to no longer allow users to add fields but instead adds a default `id` field. After saving the new table the user is redirected to the edit view of that table to add fields and relationships