### PR TITLE
Remove admin API key from the session token interceptor

### DIFF
--- a/environments/environment.ts
+++ b/environments/environment.ts
@@ -1,3 +1,0 @@
-export const environment = {
-  dfApiKey: '6498a8ad1beb9d84d63035c5d1120c007fad6de706734db9689f8996707e0f7d',
-};

--- a/src/app/shared/interceptors/session-token.interceptor.ts
+++ b/src/app/shared/interceptors/session-token.interceptor.ts
@@ -5,7 +5,6 @@ import {
 } from '@angular/common/http';
 import { DfUserDataService } from '../services/df-user-data.service';
 import { inject } from '@angular/core';
-import { environment } from '../../../../environments/environment';
 import {
   API_KEY_HEADER,
   SESSION_TOKEN_HEADER,
@@ -16,11 +15,6 @@ export const sessionTokenInterceptor: HttpInterceptorFn = (
   next: HttpHandlerFn
 ) => {
   if (req.url.startsWith('/api')) {
-    req = req.clone({
-      setHeaders: {
-        [API_KEY_HEADER]: environment.dfApiKey,
-      },
-    });
     const userDataService = inject(DfUserDataService);
     const token = userDataService.token;
     if (token) {


### PR DESCRIPTION
UPDATE Nov 12: App wouldn't work properly for non-admin users.
Probably, we should close this one.