### PR TITLE
DP-688 Adding API Health checker functionality

### DIFF
--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
@@ -76,7 +76,7 @@
     </div>
   </div>
 
-  <mat-accordion>
+  <mat-accordion *ngIf="curlCommands.length > 0">
     <mat-expansion-panel #curlCommandsPanel>
       <mat-expansion-panel-header>
         <mat-panel-title>
@@ -108,9 +108,6 @@
             </mat-card-actions>
           </mat-card>
         </div>
-        <p *ngIf="!curlCommands || curlCommands.length === 0">
-          {{ 'apiBasicCurlCommands.noCommands' | transloco }}
-        </p>
       </ng-template>
     </mat-expansion-panel>
   </mat-accordion>

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
@@ -51,8 +51,17 @@
   <div *ngIf="healthStatus === 'unhealthy'">
     <p>
       {{ 'apiHealthBanner.unhealthyBase' | transloco }}
-      <button mat-button color="accent" class="view-details-button" (click)="toggleUnhealthyErrorDetails()">
-        {{ (showUnhealthyErrorDetails ? 'apiHealthBanner.hideDetails' : 'apiHealthBanner.viewDetails') | transloco }}
+      <button
+        mat-button
+        color="accent"
+        class="view-details-button"
+        (click)="toggleUnhealthyErrorDetails()">
+        {{
+          (showUnhealthyErrorDetails
+            ? 'apiHealthBanner.hideDetails'
+            : 'apiHealthBanner.viewDetails'
+          ) | transloco
+        }}
       </button>
     </p>
     <div *ngIf="showUnhealthyErrorDetails" class="unhealthy-error-details">

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
@@ -32,4 +32,26 @@
   </mat-form-field>
 </div>
 
+<div #healthBannerElement class="api-health-banner" 
+     *ngIf="healthStatus" 
+     [ngClass]="{
+       'status-loading': healthStatus === 'loading',
+       'status-healthy': healthStatus === 'healthy',
+       'status-unhealthy': healthStatus === 'unhealthy',
+       'status-error': healthStatus === 'error'
+     }">
+  <div *ngIf="healthStatus === 'loading'">
+    <p>{{ 'apiHealthBanner.loading' | transloco }}</p>
+  </div>
+  <div *ngIf="healthStatus === 'healthy'">
+    <p>{{ 'apiHealthBanner.healthy' | transloco }}</p>
+  </div>
+  <div *ngIf="healthStatus === 'unhealthy'">
+    <p>{{ 'apiHealthBanner.unhealthy' | transloco:{ healthError: healthError } }}</p>
+  </div>
+  <div *ngIf="healthStatus === 'error'">
+    <p>{{ 'apiHealthBanner.error' | transloco:{ healthError: healthError } }}</p>
+  </div>
+</div>
+
 <div #apiDocumentation class="swagger-ui"></div>

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
@@ -40,7 +40,7 @@
     'status-loading': healthStatus === 'loading',
     'status-healthy': healthStatus === 'healthy',
     'status-unhealthy': healthStatus === 'unhealthy',
-    'status-error': healthStatus === 'error'
+    'status-warning': healthStatus === 'warning'
   }">
   <div *ngIf="healthStatus === 'loading'">
     <p>{{ 'apiHealthBanner.loading' | transloco }}</p>
@@ -50,14 +50,18 @@
   </div>
   <div *ngIf="healthStatus === 'unhealthy'">
     <p>
-      {{
-        'apiHealthBanner.unhealthy' | transloco: { healthError: healthError }
-      }}
+      {{ 'apiHealthBanner.unhealthyBase' | transloco }}
+      <button mat-button color="accent" class="view-details-button" (click)="toggleUnhealthyErrorDetails()">
+        {{ (showUnhealthyErrorDetails ? 'apiHealthBanner.hideDetails' : 'apiHealthBanner.viewDetails') | transloco }}
+      </button>
     </p>
+    <div *ngIf="showUnhealthyErrorDetails" class="unhealthy-error-details">
+      <pre>{{ healthError }}</pre>
+    </div>
   </div>
-  <div *ngIf="healthStatus === 'error'">
+  <div *ngIf="healthStatus === 'warning'">
     <p>
-      {{ 'apiHealthBanner.error' | transloco: { healthError: healthError } }}
+      {{ 'apiHealthBanner.warningDefault' | transloco }}
     </p>
   </div>
 </div>

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
@@ -32,14 +32,16 @@
   </mat-form-field>
 </div>
 
-<div #healthBannerElement class="api-health-banner" 
-     *ngIf="healthStatus" 
-     [ngClass]="{
-       'status-loading': healthStatus === 'loading',
-       'status-healthy': healthStatus === 'healthy',
-       'status-unhealthy': healthStatus === 'unhealthy',
-       'status-error': healthStatus === 'error'
-     }">
+<div
+  #healthBannerElement
+  class="api-health-banner"
+  *ngIf="healthStatus"
+  [ngClass]="{
+    'status-loading': healthStatus === 'loading',
+    'status-healthy': healthStatus === 'healthy',
+    'status-unhealthy': healthStatus === 'unhealthy',
+    'status-error': healthStatus === 'error'
+  }">
   <div *ngIf="healthStatus === 'loading'">
     <p>{{ 'apiHealthBanner.loading' | transloco }}</p>
   </div>
@@ -47,10 +49,16 @@
     <p>{{ 'apiHealthBanner.healthy' | transloco }}</p>
   </div>
   <div *ngIf="healthStatus === 'unhealthy'">
-    <p>{{ 'apiHealthBanner.unhealthy' | transloco:{ healthError: healthError } }}</p>
+    <p>
+      {{
+        'apiHealthBanner.unhealthy' | transloco: { healthError: healthError }
+      }}
+    </p>
   </div>
   <div *ngIf="healthStatus === 'error'">
-    <p>{{ 'apiHealthBanner.error' | transloco:{ healthError: healthError } }}</p>
+    <p>
+      {{ 'apiHealthBanner.error' | transloco: { healthError: healthError } }}
+    </p>
   </div>
 </div>
 

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.html
@@ -32,47 +32,88 @@
   </mat-form-field>
 </div>
 
-<div
-  #healthBannerElement
-  class="api-health-banner"
-  *ngIf="healthStatus"
-  [ngClass]="{
-    'status-loading': healthStatus === 'loading',
-    'status-healthy': healthStatus === 'healthy',
-    'status-unhealthy': healthStatus === 'unhealthy',
-    'status-warning': healthStatus === 'warning'
-  }">
-  <div *ngIf="healthStatus === 'loading'">
-    <p>{{ 'apiHealthBanner.loading' | transloco }}</p>
-  </div>
-  <div *ngIf="healthStatus === 'healthy'">
-    <p>{{ 'apiHealthBanner.healthy' | transloco }}</p>
-  </div>
-  <div *ngIf="healthStatus === 'unhealthy'">
-    <p>
-      {{ 'apiHealthBanner.unhealthyBase' | transloco }}
-      <button
-        mat-button
-        color="accent"
-        class="view-details-button"
-        (click)="toggleUnhealthyErrorDetails()">
-        {{
-          (showUnhealthyErrorDetails
-            ? 'apiHealthBanner.hideDetails'
-            : 'apiHealthBanner.viewDetails'
-          ) | transloco
-        }}
-      </button>
-    </p>
-    <div *ngIf="showUnhealthyErrorDetails" class="unhealthy-error-details">
-      <pre>{{ healthError }}</pre>
+<div #swaggerInjectedContentContainer class="custom-swagger-content-wrapper">
+  <div
+    #healthBannerElement
+    class="api-health-banner"
+    *ngIf="healthStatus"
+    [ngClass]="{
+      'status-loading': healthStatus === 'loading',
+      'status-healthy': healthStatus === 'healthy',
+      'status-unhealthy': healthStatus === 'unhealthy',
+      'status-warning': healthStatus === 'warning'
+    }">
+    <div *ngIf="healthStatus === 'loading'">
+      <p>{{ 'apiHealthBanner.loading' | transloco }}</p>
+    </div>
+    <div *ngIf="healthStatus === 'healthy'">
+      <p>{{ 'apiHealthBanner.healthy' | transloco }}</p>
+    </div>
+    <div *ngIf="healthStatus === 'unhealthy'">
+      <p>
+        {{ 'apiHealthBanner.unhealthyBase' | transloco }}
+        <button
+          mat-button
+          color="accent"
+          class="view-details-button"
+          (click)="toggleUnhealthyErrorDetails()">
+          {{
+            (showUnhealthyErrorDetails
+              ? 'apiHealthBanner.hideDetails'
+              : 'apiHealthBanner.viewDetails'
+            ) | transloco
+          }}
+        </button>
+      </p>
+      <div *ngIf="showUnhealthyErrorDetails" class="unhealthy-error-details">
+        <pre>{{ healthError }}</pre>
+      </div>
+    </div>
+    <div *ngIf="healthStatus === 'warning'">
+      <p>
+        {{ 'apiHealthBanner.warningDefault' | transloco }}
+      </p>
     </div>
   </div>
-  <div *ngIf="healthStatus === 'warning'">
-    <p>
-      {{ 'apiHealthBanner.warningDefault' | transloco }}
-    </p>
-  </div>
+
+  <mat-accordion>
+    <mat-expansion-panel #curlCommandsPanel>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          {{ 'apiBasicCurlCommands.title' | transloco }}
+        </mat-panel-title>
+      </mat-expansion-panel-header>
+
+      <ng-template matExpansionPanelContent>
+        <div
+          *ngIf="curlCommands && curlCommands.length > 0"
+          class="curl-commands-container">
+          <mat-card
+            *ngFor="let command of curlCommands; let i = index"
+            appearance="outlined">
+            <mat-card-content>
+              <pre class="curl-command-text">{{ command.text }}</pre>
+            </mat-card-content>
+            <mat-card-actions align="end" class="actions-container">
+              <button
+                mat-icon-button
+                (click)="
+                  $event.stopPropagation(); copyCurlCommand(command.text)
+                "
+                matTooltip="{{
+                  'apiBasicCurlCommands.copyTooltip' | transloco
+                }}">
+                <fa-icon size="xs" [icon]="faCopy"></fa-icon>
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        </div>
+        <p *ngIf="!curlCommands || curlCommands.length === 0">
+          {{ 'apiBasicCurlCommands.noCommands' | transloco }}
+        </p>
+      </ng-template>
+    </mat-expansion-panel>
+  </mat-accordion>
 </div>
 
 <div #apiDocumentation class="swagger-ui"></div>

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
@@ -43,6 +43,8 @@
 }
 
 .api-health-banner {
+  display: flex;
+  align-items: center;
   padding: 8px 12px;
   border-radius: 4px;
   border-left-width: 4px;
@@ -54,22 +56,73 @@
   }
 
   &.status-healthy {
-    border-left-color: #28a745; // Green
-    background-color: #e9f5ec; // Light green
-    color: #155724; // Darker green text
+    border-left-color: #28a745;
+    background-color: #e9f5ec;
+    color: #155724;
   }
 
   &.status-unhealthy,
   &.status-error {
-    border-left-color: #dc3545; // Red
-    background-color: #f8d7da; // Light red
-    color: #721c24; // Darker red text
+    border-left-color: #dc3545;
+    background-color: #f8d7da;
+    color: #721c24;
+  }
+
+  &.status-unhealthy {
+    & > div {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      width: 100%;
+
+      & > p {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+
+        .view-details-button {
+          margin-left: 12px;
+          flex-shrink: 0;
+          padding: 2px 8px;
+          line-height: normal;
+          font-size: 0.9em;
+          min-width: auto;
+        }
+      }
+
+      .unhealthy-error-details {
+        margin-top: 0;
+        padding: 8px 12px;
+        background-color: rgba(0, 0, 0, 0.03);
+        border: 1px solid rgba(0, 0, 0, 0.06);
+        border-radius: 4px;
+        width: 100%;
+        box-sizing: border-box;
+        max-height: 150px;
+        overflow-y: auto;
+
+        pre {
+          margin: 0;
+          white-space: pre-wrap;
+          word-break: break-word;
+          font-size: 0.85em;
+          color: inherit;
+        }
+      }
+    }
   }
 
   &.status-loading {
-    border-left-color: #007bff; // Blue
-    background-color: #e7f3ff; // Light blue
-    color: #004085; // Darker blue text
+    border-left-color: #007bff;
+    background-color: #e7f3ff;
+    color: #004085;
+  }
+
+  &.status-warning {
+    border-left-color: #ffc107;
+    background-color: #fff3cd;
+    color: #856404;
   }
 }
 
@@ -82,6 +135,7 @@
         display: flex;
         justify-content: space-between;
         flex-direction: row-reverse;
+        gap: 8px;
       }
     }
   }

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
@@ -41,3 +41,48 @@
 .swagger-ui {
   margin-top: 16px;
 }
+
+.api-health-banner {
+  padding: 8px 12px;
+  border-radius: 4px;
+  border-left-width: 4px;
+  border-left-style: solid;
+
+  p {
+    margin: 0;
+    font-size: 0.9em;
+  }
+
+  &.status-healthy {
+    border-left-color: #28a745; // Green
+    background-color: #e9f5ec; // Light green
+    color: #155724; // Darker green text
+  }
+
+  &.status-unhealthy,
+  &.status-error {
+    border-left-color: #dc3545; // Red
+    background-color: #f8d7da; // Light red
+    color: #721c24; // Darker red text
+  }
+
+  &.status-loading {
+    border-left-color: #007bff; // Blue
+    background-color: #e7f3ff; // Light blue
+    color: #004085; // Darker blue text
+  }
+}
+
+// Styles for elements within Swagger UI, piercing encapsulation
+:host ::ng-deep {
+  .swagger-ui {
+    // This targets the wrapper div for Swagger UI in your component's template
+    .information-container {
+      .main {
+        display: flex;
+        justify-content: space-between;
+        flex-direction: row-reverse;
+      }
+    }
+  }
+}

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.scss
@@ -134,9 +134,31 @@
       .main {
         display: flex;
         justify-content: space-between;
-        flex-direction: row-reverse;
+        flex-wrap: wrap;
         gap: 8px;
       }
     }
+  }
+}
+
+.curl-command-text {
+  white-space: pre;
+  font-family: monospace;
+  font-size: 0.9em;
+  margin: 0;
+  color: var(--df-script-editor-text-color);
+  overflow-x: auto;
+}
+
+.custom-swagger-content-wrapper {
+  width: 100%;
+}
+
+.curl-commands-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  .actions-container {
+    padding: 0px 8px;
   }
 }

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
@@ -135,9 +135,7 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
     this.subscriptions.push(
       this.activatedRoute.data.subscribe(({ data }) => {
         if (data) {
-          if (
-            data.paths['/']?.get?.operationId === 'getSoapResources'
-          ) {
+          if (data.paths['/']?.get?.operationId === 'getSoapResources') {
             this.apiDocJson = { ...data, paths: mapSnakeToCamel(data.paths) };
           } else {
             this.apiDocJson = { ...data, paths: mapCamelToSnake(data.paths) };
@@ -232,13 +230,19 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
   private checkApiHealth(): void {
     if (this.serviceName && this.apiDocJson?.paths['/_schema']?.get) {
       // Perform health check
-      this.performHealthCheck(this.serviceName, `${BASE_URL}/${this.serviceName}/_schema`);
+      this.performHealthCheck(
+        this.serviceName,
+        `${BASE_URL}/${this.serviceName}/_schema`
+      );
     } else {
       this.setHealthState('warning');
     }
   }
 
-  private setHealthState(status: 'healthy' | 'unhealthy' | 'warning', error: string | null = null): void {
+  private setHealthState(
+    status: 'healthy' | 'unhealthy' | 'warning',
+    error: string | null = null
+  ): void {
     this.healthStatus = status;
     this.healthError = error;
   }
@@ -248,18 +252,21 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
     this.healthError = null;
 
     this.subscriptions.push(
-      this.http.get(url).pipe(
-        tap(() => this.setHealthState('healthy')),
-        catchError((error: HttpErrorResponse) => {
-          if (error.status >= 200 && error.status < 300) {
-            this.setHealthState('healthy');
-            return of(null);
-          }
+      this.http
+        .get(url)
+        .pipe(
+          tap(() => this.setHealthState('healthy')),
+          catchError((error: HttpErrorResponse) => {
+            if (error.status >= 200 && error.status < 300) {
+              this.setHealthState('healthy');
+              return of(null);
+            }
 
-          this.setHealthState('unhealthy', error.message || 'Unknown error');
-          return of(null);
-        })
-      ).subscribe()
+            this.setHealthState('unhealthy', error.message || 'Unknown error');
+            return of(null);
+          })
+        )
+        .subscribe()
     );
   }
 

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
@@ -329,9 +329,6 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
         const sessionToken = this.userDataService.token
           ? this.userDataService.token
           : 'YOUR_SESSION_TOKEN';
-
-        console.log(`${BASE_URL}/${this.serviceName}${endpoint}`);
-          
         const command = `curl -X 'GET' '${window.location.origin}${BASE_URL}/${this.serviceName}${endpoint}' -H 'accept: application/json' -H '${SESSION_TOKEN_HEADER}: ${sessionToken}'`;
         this.curlCommands.push({ text: command });
       });

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
@@ -34,7 +34,13 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { DfCurrentServiceService } from 'src/app/shared/services/df-current-service.service';
-import { tap, switchMap, map, distinctUntilChanged, catchError } from 'rxjs/operators';
+import {
+  tap,
+  switchMap,
+  map,
+  distinctUntilChanged,
+  catchError,
+} from 'rxjs/operators';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { BASE_URL } from 'src/app/shared/constants/urls';
 import { Subscription, of } from 'rxjs';
@@ -71,7 +77,9 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
   @ViewChild('apiDocumentation', { static: true }) apiDocElement:
     | ElementRef
     | undefined;
-  @ViewChild('healthBannerElement') healthBannerElementRef: ElementRef | undefined;
+  @ViewChild('healthBannerElement') healthBannerElementRef:
+    | ElementRef
+    | undefined;
 
   apiDocJson: object;
   apiKeys: ApiKeyInfo[] = [];
@@ -118,23 +126,26 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
       // Perform health check
       this.healthStatus = 'loading';
       this.subscriptions.push(
-        this.http.get(`${BASE_URL}/${this.serviceName}/_schema`).pipe(
-          tap(() => {
-            this.healthStatus = 'healthy';
-            this.healthError = null;
-          }),
-          catchError((error: HttpErrorResponse) => {
-            if (error.status >= 200 && error.status < 300) {
-               // Even if there's an error in parsing, if it's 2xx, consider it healthy for schema check
-              this.healthStatus = 'healthy'; 
+        this.http
+          .get(`${BASE_URL}/${this.serviceName}/_schema`)
+          .pipe(
+            tap(() => {
+              this.healthStatus = 'healthy';
               this.healthError = null;
-            } else {
-              this.healthStatus = 'unhealthy';
-              this.healthError = error.message || 'Unknown error';
-            }
-            return of(null); // Continue the stream
-          })
-        ).subscribe()
+            }),
+            catchError((error: HttpErrorResponse) => {
+              if (error.status >= 200 && error.status < 300) {
+                // Even if there's an error in parsing, if it's 2xx, consider it healthy for schema check
+                this.healthStatus = 'healthy';
+                this.healthError = null;
+              } else {
+                this.healthStatus = 'unhealthy';
+                this.healthError = error.message || 'Unknown error';
+              }
+              return of(null); // Continue the stream
+            })
+          )
+          .subscribe()
       );
     }
 
@@ -193,12 +204,19 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
       },
       showMutatedRequest: true,
       onComplete: () => {
-        if (this.healthBannerElementRef && this.healthBannerElementRef.nativeElement && this.apiDocElement && this.apiDocElement.nativeElement) {
+        if (
+          this.healthBannerElementRef &&
+          this.healthBannerElementRef.nativeElement &&
+          this.apiDocElement &&
+          this.apiDocElement.nativeElement
+        ) {
           const swaggerContainer = this.apiDocElement.nativeElement;
           const bannerNode = this.healthBannerElementRef.nativeElement;
 
           // Try to find the information container within Swagger UI
-          const infoContainer = swaggerContainer.querySelector('.information-container .main');
+          const infoContainer = swaggerContainer.querySelector(
+            '.information-container .main'
+          );
 
           if (infoContainer) {
             // Prepend banner to the information container (which typically holds the title)
@@ -210,13 +228,16 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
           } else {
             // Fallback: Prepend to the main swagger container if .information-container is not found
             if (swaggerContainer.firstChild) {
-              swaggerContainer.insertBefore(bannerNode, swaggerContainer.firstChild);
+              swaggerContainer.insertBefore(
+                bannerNode,
+                swaggerContainer.firstChild
+              );
             } else {
               swaggerContainer.appendChild(bannerNode);
             }
           }
         }
-      }
+      },
     });
   }
 

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
@@ -108,7 +108,12 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
   healthError: string | null = null;
   serviceName: string | null = null;
   showUnhealthyErrorDetails = false;
-  private static SUPPORTED_SERVICE_TYPE_GROUPS = ['Database', 'File'];
+  private static SUPPORTED_SERVICE_TYPE_GROUPS = [
+    'Database',
+    'File',
+    'User',
+    'System',
+  ];
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -274,6 +279,7 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
           if (!Object.prototype.hasOwnProperty.call(methods, method)) {
             continue;
           }
+
           if (method.toLowerCase() === 'get') {
             const operation = methods[method];
             const parameters: Array<{
@@ -283,12 +289,21 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
             }> = operation.parameters || [];
 
             const hasPathParameters = path.includes('{');
-
             const hasRequiredQueryParameters = parameters.some(
               param => param && param.in === 'query' && param.required === true
             );
 
-            if (!hasPathParameters && !hasRequiredQueryParameters) {
+            const isSystemServiceRelatedPath =
+              (path.includes('/admin') || path.includes('/service_report')) &&
+              this.apiDocJson.info.group === 'System';
+
+            const isNonRootAdmin = !this.userDataService.userData?.isRootAdmin;
+
+            if (
+              !hasPathParameters &&
+              !hasRequiredQueryParameters &&
+              !(isNonRootAdmin && isSystemServiceRelatedPath)
+            ) {
               endpointsToValidate.push(path);
             }
           }

--- a/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
+++ b/src/app/adf-api-docs/df-api-docs/df-api-docs.component.ts
@@ -108,12 +108,7 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
   healthError: string | null = null;
   serviceName: string | null = null;
   showUnhealthyErrorDetails = false;
-  private static SUPPORTED_SERVICE_TYPE_GROUPS = [
-    'Database',
-    'File',
-    'User',
-    'System',
-  ];
+  private static SUPPORTED_SERVICE_TYPE_GROUPS = ['Database', 'File'];
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -279,7 +274,6 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
           if (!Object.prototype.hasOwnProperty.call(methods, method)) {
             continue;
           }
-
           if (method.toLowerCase() === 'get') {
             const operation = methods[method];
             const parameters: Array<{
@@ -289,21 +283,12 @@ export class DfApiDocsComponent implements OnInit, AfterContentInit, OnDestroy {
             }> = operation.parameters || [];
 
             const hasPathParameters = path.includes('{');
+
             const hasRequiredQueryParameters = parameters.some(
               param => param && param.in === 'query' && param.required === true
             );
 
-            const isSystemServiceRelatedPath =
-              (path.includes('/admin') || path.includes('/service_report')) &&
-              this.apiDocJson.info.group === 'System';
-
-            const isNonRootAdmin = !this.userDataService.userData?.isRootAdmin;
-
-            if (
-              !hasPathParameters &&
-              !hasRequiredQueryParameters &&
-              !(isNonRootAdmin && isSystemServiceRelatedPath)
-            ) {
+            if (!hasPathParameters && !hasRequiredQueryParameters) {
               endpointsToValidate.push(path);
             }
           }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -120,8 +120,10 @@
   "apiHealthBanner": {
     "loading": "Checking API status...",
     "healthy": "API status: Healthy",
-    "unhealthy": "API status: Unhealthy. {{healthError}}",
-    "error": "Error checking API status. {{healthError}}"
+    "unhealthyBase": "API status: Unhealthy.",
+    "viewDetails": "View Details",
+    "hideDetails": "Hide Details",
+    "warningDefault": "Warning: This type of API currently does not support automatic health checks."
   },
   "nav": {
     "error": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -117,6 +117,12 @@
     "python3": "Python3",
     "nodejs": "Node.js"
   },
+  "apiHealthBanner": {
+    "loading": "Checking API status...",
+    "healthy": "API status: Healthy",
+    "unhealthy": "API status: Unhealthy. {{healthError}}",
+    "error": "Error checking API status. {{healthError}}"
+  },
   "nav": {
     "error": {
       "header": "Error"

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -125,6 +125,10 @@
     "hideDetails": "Hide Details",
     "warningDefault": "Warning: This type of API currently does not support automatic health checks."
   },
+  "apiBasicCurlCommands": {
+    "title": "Test api yourself with this simple curl commads here:",
+    "copyTooltip": "Copy"
+  },
   "nav": {
     "error": {
       "header": "Error"


### PR DESCRIPTION
### Summary of Changes

This PR introduces basic health checker components designed to validate critical API endpoints. The initial implementation focuses on two types of APIs: Database and File APIs.

### Details

- **Health Checker Implementation**: 
  - For **Database APIs**, a GET request is triggered to the endpoint `/_schema`. 
  - For **File APIs**, a GET request is made to the endpoint `/`.
  
- **Curl Command Generator**: 
  - Added a new component that generates simple curl commands, allowing users to easily test and interact with the API endpoints.

### Benefits

- **Improved Monitoring**: The health checker enhances our ability to monitor API health.
- **User-Friendly Testing**: The curl command generator provides a straightforward way for users to experiment with the APIs.

### Next Steps

- Consider extending health check coverage to other API types in future iterations.
- Gather feedback from team members on the usability of the curl command generator.

Here is a GIF demo on how it works:
![recording](https://github.com/user-attachments/assets/16dd98f2-577e-435a-962e-aec70e5eab1a)