### PR TITLE
docs: mark df-admin-interface as Laravel 13-transparent

### DIFF
--- a/LARAVEL_13_COMPAT.md
+++ b/LARAVEL_13_COMPAT.md
@@ -1,0 +1,53 @@
+# Laravel 13 Compatibility Notes
+
+This repo is the **Angular 16 admin UI** for DreamFactory. It is a frontend-only
+package and has no PHP / Laravel runtime dependency. As part of the
+DreamFactory Laravel 11 -> 13 upgrade campaign (Waves 0-5), this package was
+audited for compatibility against the L13 backend.
+
+## Audit result: L13-transparent
+
+**No code changes are required for the UI to function against the Laravel 13
+backend.** This document captures why, so future contributors don't need to
+re-derive it.
+
+### What was audited
+
+1. **API endpoints** consumed by the UI (`src/app/shared/constants/urls.ts`
+   and call sites grepped under `src/`). All paths live under `/api/v2/...`
+   and are served by `df-core` / `df-user` / `df-system`, which are upgraded
+   to L13 as composer-only bumps with no route or contract changes.
+2. **Auth endpoints**: `/api/v2/system/admin/session`, `/api/v2/user/session`,
+   `/api/v2/system/admin/password`, `/api/v2/user/password`,
+   `/api/v2/user/register`. All unchanged.
+3. **Error envelope**: the UI's HTTP interceptors
+   (`src/app/shared/interceptors/error.interceptor.ts`,
+   `src/app/shared/interceptors/snackbar.interceptor.ts`) and many feature
+   components consume DreamFactory's custom error envelope:
+   ```json
+   { "error": { "message": "...", "code": 400, "context": { ... } } }
+   ```
+   This envelope is produced by `df-core`'s exception handler, **not** by
+   Laravel's default JSON error formatter. Default-Laravel JSON error shape
+   changes between L11 and L13 (`message` / `exception` / `file` keys) do not
+   reach this UI.
+4. **Composer coupling**: `composer.json` declares only
+   `dreamfactory/installer: *`, a Composer installer plugin that stages the
+   built `dist/` artifact into the host app's public dir. There is no
+   Laravel framework dependency here.
+
+### What was NOT audited (out of scope)
+
+- **Angular 16 modernization**: Angular 16 reached end-of-life in November
+  2024. The UI will continue to function against L13, but Angular itself
+  should be modernized in a separate track (Angular 17 / 18 / 19), decoupled
+  from the L13 upgrade.
+- **Backend-driven UI features** (e.g., new admin screens for L13-specific
+  features): none are planned for the L13 upgrade — Waves 0-5 are mechanical
+  framework bumps, not feature work.
+
+## Campaign tracking
+
+This package is recorded in the campaign as **L13-transparent: docs-only
+alignment PR**. See the corresponding shift/laravel-13 PRs in sibling
+DreamFactory packages for the broader upgrade context.


### PR DESCRIPTION
## Summary

This PR is part of the DreamFactory **Laravel 11 -> 13 upgrade campaign**
(Waves 0-5). df-admin-interface is the Angular 16 admin UI and has no
PHP/Laravel runtime coupling, so a code change is not required to maintain
compatibility with the L13 backend.

This is a **docs-only alignment PR** so the campaign has a tracked
shift/laravel-13 branch + PR for this package alongside the backend
packages.

## Audit findings (see LARAVEL_13_COMPAT.md)

- All consumed API paths under `/api/v2/...` are stable across the L13
  upgrade — verified against df-core / df-user / df-system shift/laravel-13
  branches in Waves 0-1.
- Auth endpoints (`/api/v2/system/admin/session`, `/api/v2/user/session`,
  password / register flows) unchanged.
- The UI's HTTP interceptors consume df-core's custom error envelope
  (`{ error: { message, code, context } }`), not Laravel's default JSON
  error shape, so L11 -> L13 default-error format changes do not reach the UI.
- `composer.json` declares only `dreamfactory/installer: *` — no Laravel
  framework dependency.

## Out of scope (flagged for future work)

- Angular 16 reached end-of-life in November 2024. A separate modernization
  track (Angular 17/18/19) is recommended, decoupled from this L13 upgrade.

## Test plan

- [x] No code changes — docs-only.
- [x] `composer.json` audited: zero Laravel dep.
- [x] `src/app/shared/constants/urls.ts` audited: all `/api/v2/...` paths
      stable in L13 backend.
- [x] HTTP interceptors audited: custom df-core error envelope, not Laravel
      default JSON shape.
- [ ] Smoke verify UI still loads against the L13 backend once the host
      app's `shift-173254` branch is deployable end-to-end (deferred to
      Wave 5 integration testing).